### PR TITLE
Update ros2_control.xacro to match humble branch of diffdrive_arduino

### DIFF
--- a/description/ros2_control.xacro
+++ b/description/ros2_control.xacro
@@ -4,13 +4,13 @@
     <xacro:unless value="$(arg sim_mode)">
         <ros2_control name="RealRobot" type="system">
             <hardware>
-                <plugin>diffdrive_arduino/DiffDriveArduino</plugin>
+                <plugin>diffdrive_arduino/DiffDriveArduinoHardware</plugin>
                 <param name="left_wheel_name">left_wheel_joint</param>
                 <param name="right_wheel_name">right_wheel_joint</param>
                 <param name="loop_rate">30</param>
                 <param name="device">/dev/ttyUSB0</param>
                 <param name="baud_rate">57600</param>
-                <param name="timeout">1000</param>
+                <param name="timeout_ms">1000</param>
                 <param name="enc_counts_per_rev">3436</param>
             </hardware>
             <joint name="left_wheel_joint">
@@ -18,16 +18,16 @@
                     <param name="min">-10</param>
                     <param name="max">10</param>
                 </command_interface>
-                <state_interface name="velocity"/>
                 <state_interface name="position"/>
+                <state_interface name="velocity"/>
             </joint>
             <joint name="right_wheel_joint">
                 <command_interface name="velocity">
                     <param name="min">-10</param>
                     <param name="max">10</param>
                 </command_interface>
-                <state_interface name="velocity"/>
                 <state_interface name="position"/>
+                <state_interface name="velocity"/>
             </joint>
         </ros2_control>
     </xacro:unless>


### PR DESCRIPTION
I edited a few lines in ros2_control.xacro file to match the humble branch of the [diffdrive_arduino repo](https://github.com/joshnewans/diffdrive_arduino) (otherwise there will be runtime error).